### PR TITLE
Corrige erro de disable registrando e cancelando tasks assíncronas

### DIFF
--- a/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
+++ b/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
@@ -113,7 +113,10 @@ public abstract class BaseGame {
         final Integer startingTimes = getConfig().getAnnouncementStartingTimes();
         lobbyTask = new LobbyAnnouncementTask(startingTimes, interval);
         addTask(lobbyTask.runTaskTimer(plugin, 0, interval * 20L));
-        addTask(new LobbyWantingAnnouncementTask((startingTimes + 1L) * interval).runTaskTimerAsynchronously(plugin, 0, 20L));
+        final BukkitTask lobbyWantingTask = new LobbyWantingAnnouncementTask((startingTimes + 1L) * interval)
+                .runTaskTimerAsynchronously(plugin, 0, 20L);
+        addTask(lobbyWantingTask);
+        plugin.registerAsyncTask(lobbyWantingTask);
     }
 
     public void finish(final boolean cancelled) {
@@ -128,7 +131,11 @@ public abstract class BaseGame {
         if (getConfig().isWorldBorder()) {
             getConfig().getBorderCenter().getWorld().getWorldBorder().reset();
         }
-        Bukkit.getScheduler().runTask(plugin, () -> plugin.getDatabaseManager().saveAll());
+        if (plugin.isEnabled() && !plugin.isShuttingDown()) {
+            Bukkit.getScheduler().runTask(plugin, () -> plugin.getDatabaseManager().saveAll());
+        } else {
+            plugin.getDatabaseManager().saveAllSync();
+        }
         if (!cancelled) {
             processWinners();
         }

--- a/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
+++ b/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
@@ -32,6 +32,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.IllegalPluginAccessException;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
@@ -132,7 +133,11 @@ public abstract class BaseGame {
             getConfig().getBorderCenter().getWorld().getWorldBorder().reset();
         }
         if (plugin.isEnabled() && !plugin.isShuttingDown()) {
-            Bukkit.getScheduler().runTask(plugin, () -> plugin.getDatabaseManager().saveAll());
+            try {
+                Bukkit.getScheduler().runTask(plugin, () -> plugin.getDatabaseManager().saveAll());
+            } catch (final IllegalPluginAccessException e) {
+                plugin.getDatabaseManager().saveAllSync();
+            }
         } else {
             plugin.getDatabaseManager().saveAllSync();
         }

--- a/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
+++ b/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
@@ -500,7 +500,10 @@ public abstract class BaseGame {
     }
 
     protected void killTasks() {
-        tasks.forEach(BukkitTask::cancel);
+        tasks.forEach(task -> {
+            task.cancel();
+            plugin.unregisterAsyncTask(task);
+        });
         tasks.clear();
     }
 

--- a/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
+++ b/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
@@ -53,6 +53,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,6 +61,9 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 /**
@@ -82,6 +86,8 @@ public final class TitansBattle extends JavaPlugin {
     private SpectateManager spectateManager;
     private NpcProvider npcProvider;
     private DisconnectTrackingManager disconnectTrackingManager;
+    private final Set<BukkitTask> asyncTasks = ConcurrentHashMap.newKeySet();
+    private volatile boolean shuttingDown;
 
     public static TitansBattle getInstance() {
         return instance;
@@ -165,6 +171,8 @@ public final class TitansBattle extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        shuttingDown = true;
+        cancelRegisteredAsyncTasks();
         challengeManager.getChallenges().forEach(c -> c.cancel(Bukkit.getConsoleSender()));
         gameManager.getCurrentGame().ifPresent(g -> g.cancel(Bukkit.getConsoleSender()));
         if (npcProvider != null) {
@@ -312,7 +320,7 @@ public final class TitansBattle extends JavaPlugin {
     }
 
     public void sendDiscordMessage(final String message) {
-        Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+        runTrackedAsyncTask(() -> {
             final String url = getConfig().getString("discord_webhook_url");
             if (url != null && !url.isEmpty()) {
                 final DiscordWebhook webhook = new DiscordWebhook(url);
@@ -326,6 +334,56 @@ public final class TitansBattle extends JavaPlugin {
                 }
             }
         });
+    }
+
+    /**
+     * Returns whether the plugin shutdown routine has already started.
+     *
+     * @return {@code true} when disabling is in progress; otherwise {@code false}
+     */
+    public boolean isShuttingDown() {
+        return shuttingDown;
+    }
+
+    /**
+     * Registers an asynchronous Bukkit task so it can be cancelled during plugin shutdown.
+     *
+     * @param task asynchronous task to track
+     */
+    public void registerAsyncTask(@NotNull final BukkitTask task) {
+        asyncTasks.add(task);
+    }
+
+    /**
+     * Schedules and tracks an asynchronous one-shot task tied to this plugin.
+     *
+     * @param runnable async action to execute
+     */
+    public void runTrackedAsyncTask(@NotNull final Runnable runnable) {
+        if (shuttingDown || !isEnabled()) {
+            return;
+        }
+        final AtomicReference<BukkitTask> taskRef = new AtomicReference<>();
+        final BukkitTask task = Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+            try {
+                runnable.run();
+            } finally {
+                final BukkitTask runningTask = taskRef.get();
+                if (runningTask != null) {
+                    asyncTasks.remove(runningTask);
+                }
+            }
+        });
+        taskRef.set(task);
+        asyncTasks.add(task);
+    }
+
+    /**
+     * Cancels every tracked asynchronous task registered by this plugin.
+     */
+    public void cancelRegisteredAsyncTasks() {
+        asyncTasks.forEach(BukkitTask::cancel);
+        asyncTasks.clear();
     }
 
     /**

--- a/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
+++ b/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
@@ -52,6 +52,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.IllegalPluginAccessException;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
@@ -88,6 +89,7 @@ public final class TitansBattle extends JavaPlugin {
     private NpcProvider npcProvider;
     private DisconnectTrackingManager disconnectTrackingManager;
     private final Set<BukkitTask> asyncTasks = ConcurrentHashMap.newKeySet();
+    private final Object taskLock = new Object();
     private volatile boolean shuttingDown;
 
     public static TitansBattle getInstance() {
@@ -352,7 +354,13 @@ public final class TitansBattle extends JavaPlugin {
      * @param task asynchronous task to track
      */
     public void registerAsyncTask(@NotNull final BukkitTask task) {
-        asyncTasks.add(task);
+        synchronized (taskLock) {
+            if (shuttingDown || !isEnabled()) {
+                task.cancel();
+                return;
+            }
+            asyncTasks.add(task);
+        }
     }
 
     /**
@@ -375,21 +383,44 @@ public final class TitansBattle extends JavaPlugin {
         }
         final AtomicReference<BukkitTask> taskRef = new AtomicReference<>();
         final CountDownLatch taskRegistered = new CountDownLatch(1);
-        final BukkitTask task = Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
-            try {
-                taskRegistered.await();
-                runnable.run();
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } finally {
-                final BukkitTask runningTask = taskRef.get();
-                if (runningTask != null) {
-                    asyncTasks.remove(runningTask);
+        final BukkitTask task;
+        try {
+            task = Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+                try {
+                    taskRegistered.await();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    final BukkitTask runningTask = taskRef.get();
+                    if (runningTask != null) {
+                        asyncTasks.remove(runningTask);
+                    }
+                    return;
                 }
-            }
-        });
+                if (shuttingDown || !isEnabled()) {
+                    return;
+                }
+                try {
+                    runnable.run();
+                } finally {
+                    final BukkitTask runningTask = taskRef.get();
+                    if (runningTask != null) {
+                        asyncTasks.remove(runningTask);
+                    }
+                }
+            });
+        } catch (final IllegalPluginAccessException e) {
+            debug("Skipping async task scheduling: plugin is already disabled", false);
+            return;
+        }
         taskRef.set(task);
-        asyncTasks.add(task);
+        synchronized (taskLock) {
+            if (shuttingDown || !isEnabled()) {
+                task.cancel();
+                taskRegistered.countDown();
+                return;
+            }
+            asyncTasks.add(task);
+        }
         taskRegistered.countDown();
     }
 
@@ -397,8 +428,10 @@ public final class TitansBattle extends JavaPlugin {
      * Cancels every tracked asynchronous task registered by this plugin.
      */
     public void cancelRegisteredAsyncTasks() {
-        asyncTasks.forEach(BukkitTask::cancel);
-        asyncTasks.clear();
+        synchronized (taskLock) {
+            asyncTasks.forEach(BukkitTask::cancel);
+            asyncTasks.clear();
+        }
     }
 
     /**

--- a/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
+++ b/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
@@ -364,9 +365,13 @@ public final class TitansBattle extends JavaPlugin {
             return;
         }
         final AtomicReference<BukkitTask> taskRef = new AtomicReference<>();
+        final CountDownLatch taskRegistered = new CountDownLatch(1);
         final BukkitTask task = Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
             try {
+                taskRegistered.await();
                 runnable.run();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
             } finally {
                 final BukkitTask runningTask = taskRef.get();
                 if (runningTask != null) {
@@ -376,6 +381,7 @@ public final class TitansBattle extends JavaPlugin {
         });
         taskRef.set(task);
         asyncTasks.add(task);
+        taskRegistered.countDown();
     }
 
     /**

--- a/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
+++ b/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
@@ -356,6 +356,15 @@ public final class TitansBattle extends JavaPlugin {
     }
 
     /**
+     * Stops tracking an asynchronous Bukkit task when it is no longer needed.
+     *
+     * @param task asynchronous task to untrack
+     */
+    public void unregisterAsyncTask(@NotNull final BukkitTask task) {
+        asyncTasks.remove(task);
+    }
+
+    /**
      * Schedules and tracks an asynchronous one-shot task tied to this plugin.
      *
      * @param runnable async action to execute

--- a/src/main/java/me/roinujnosde/titansbattle/managers/DatabaseManager.java
+++ b/src/main/java/me/roinujnosde/titansbattle/managers/DatabaseManager.java
@@ -475,28 +475,54 @@ public class DatabaseManager {
         final Set<Warrior> warriorsSet = new HashSet<>(getWarriors());
         final List<Winners> winnersList = new ArrayList<>(getWinners());
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            for (final Map.Entry<String, GroupData> data : groupMap.entrySet()) {
-                if (data.getValue().isModified()) {
-                    update(data.getKey(), data.getValue());
-                    data.getValue().setModified(false);
-                }
-            }
+        if (!plugin.isEnabled() || plugin.isShuttingDown()) {
+            persistModifiedData(groupMap, warriorsSet, winnersList);
+            return;
+        }
 
-            for (final Warrior warrior : warriorsSet) {
-                if (warrior.isModified()) {
-                    update(warrior);
-                    warrior.setModified(false);
-                }
-            }
+        plugin.runTrackedAsyncTask(() -> persistModifiedData(groupMap, warriorsSet, winnersList));
+    }
 
-            for (final Winners winner : winnersList) {
-                if (winner.isModified()) {
-                    update(winner);
-                    winner.setModified(false);
-                }
+    /**
+     * Persists all in-memory data synchronously, intended for plugin shutdown flow.
+     */
+    public void saveAllSync() {
+        final Map<String, GroupData> groupMap = new HashMap<>(getGroups());
+        final Set<Warrior> warriorsSet = new HashSet<>(getWarriors());
+        final List<Winners> winnersList = new ArrayList<>(getWinners());
+        persistModifiedData(groupMap, warriorsSet, winnersList);
+    }
+
+    /**
+     * Persists modified entities to storage and clears their modified flags.
+     *
+     * @param groupMap groups snapshot
+     * @param warriorsSet warriors snapshot
+     * @param winnersList winners snapshot
+     */
+    private void persistModifiedData(@NotNull final Map<String, GroupData> groupMap,
+                                     @NotNull final Set<Warrior> warriorsSet,
+                                     @NotNull final List<Winners> winnersList) {
+        for (final Map.Entry<String, GroupData> data : groupMap.entrySet()) {
+            if (data.getValue().isModified()) {
+                update(data.getKey(), data.getValue());
+                data.getValue().setModified(false);
             }
-        });
+        }
+
+        for (final Warrior warrior : warriorsSet) {
+            if (warrior.isModified()) {
+                update(warrior);
+                warrior.setModified(false);
+            }
+        }
+
+        for (final Winners winner : winnersList) {
+            if (winner.isModified()) {
+                update(winner);
+                winner.setModified(false);
+            }
+        }
     }
 
     public Winners getLatestWinners() {


### PR DESCRIPTION
### Motivation
- Evitar `IllegalPluginAccessException` causado por agendamento de tasks quando o plugin já está em processo de desligamento.
- Garantir que todas as tasks assíncronas do plugin sejam rastreadas e canceláveis durante o `onDisable()` para permitir um shutdown seguro.

### Description
- Adiciona rastreador global `asyncTasks`, flag `shuttingDown` e os métodos documentados `registerAsyncTask`, `runTrackedAsyncTask`, `cancelRegisteredAsyncTasks` e `isShuttingDown` em `TitansBattle` para controlar tasks assíncronas.
- Marca `shuttingDown = true` e chama `cancelRegisteredAsyncTasks()` imediatamente no início de `onDisable()` para interromper execuções assíncronas pendentes antes do cancelamento de games/challenges.
- Altera `BaseGame.start()` para registrar a task assíncrona de lobby no rastreador do plugin usando `plugin.registerAsyncTask(...)` para manter controle centralizado.
- Evita agendar uma task síncrona em `BaseGame.finish()` quando o plugin está em shutdown, usando `plugin.isEnabled()`/`isShuttingDown()` e fazendo fallback para `DatabaseManager.saveAllSync()`; adiciona `saveAllSync()` e `persistModifiedData(...)` em `DatabaseManager` e refatora `saveAll()` para usar `runTrackedAsyncTask` quando apropriado.
- Substitui chamadas diretas a `Bukkit.getScheduler().runTaskAsynchronously(...)` por `runTrackedAsyncTask(...)` no envio de webhook para que sejam rastreadas e canceláveis.

### Testing
- Compilação com Maven executada: `mvn -q -DskipTests compile` concluída com sucesso.
- Build verificado localmente após alterações, sem erros de compilação relacionados às mudanças realizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8864ec5388322825b470b440ccc48)