### PR TITLE
Follow-up: untrack per-game async tasks on finish

### DIFF
--- a/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
+++ b/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
@@ -500,7 +500,10 @@ public abstract class BaseGame {
     }
 
     protected void killTasks() {
-        tasks.forEach(BukkitTask::cancel);
+        tasks.forEach(task -> {
+            task.cancel();
+            plugin.unregisterAsyncTask(task);
+        });
         tasks.clear();
     }
 

--- a/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
+++ b/src/main/java/me/roinujnosde/titansbattle/TitansBattle.java
@@ -355,6 +355,15 @@ public final class TitansBattle extends JavaPlugin {
     }
 
     /**
+     * Stops tracking an asynchronous Bukkit task when it is no longer needed.
+     *
+     * @param task asynchronous task to untrack
+     */
+    public void unregisterAsyncTask(@NotNull final BukkitTask task) {
+        asyncTasks.remove(task);
+    }
+
+    /**
      * Schedules and tracks an asynchronous one-shot task tied to this plugin.
      *
      * @param runnable async action to execute


### PR DESCRIPTION
### Motivation
- Game-scoped asynchronous tasks registered in the plugin-wide `asyncTasks` set were not removed when games finished, allowing canceled/completed tasks to accumulate over many game cycles. 
- Reviewer feedback requested deterministic removal of per-game tasks from the global tracker to avoid memory growth and extra shutdown work.

### Description
- Added `unregisterAsyncTask(BukkitTask)` in `TitansBattle` to allow explicit removal of a task from the global async tracker (`src/main/java/me/roinujnosde/titansbattle/TitansBattle.java`).
- Updated `BaseGame.killTasks()` to cancel each task and call `plugin.unregisterAsyncTask(task)` before clearing the local `tasks` list (`src/main/java/me/roinujnosde/titansbattle/BaseGame.java`).

### Testing
- Ran a build compile with `mvn -q -DskipTests compile`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db46b393dc8322a4fb8a71d4ff4462)